### PR TITLE
Fix: Add automatic detection for portable vs regular ComfyUI installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A ComfyUI custom node that provides an easy-to-use interface for installing the 
 ## Features
 
 - 🐍 **Multi-Python Support**: Supports Python 3.10, 3.11, and 3.12
-- 🔧 **Installation Type Detection**: Handles both regular and portable ComfyUI installations
+- 🔧 **Auto-Detection**: Automatically detects portable vs regular ComfyUI installations
 - 📦 **Automatic Downloads**: Downloads wheels directly to your ComfyUI root directory
 - ⚡ **Smart Detection**: Automatically detects your ComfyUI root directory
 - 🛡️ **Robust Error Handling**: Comprehensive error handling with clear user feedback
@@ -42,7 +42,7 @@ A ComfyUI custom node that provides an easy-to-use interface for installing the 
 
 2. **Configure Settings**:
    - **Python Version**: Select your Python version (3.10, 3.11, or 3.12)
-   - **Installation Type**: Choose between "Regular ComfyUI" or "Portable ComfyUI"
+   - **Installation Type**: Auto-detected (Portable/Regular), but can be manually overridden if needed
    - **Force Reinstall**: Enable if you want to reinstall even if Insightface is already present
 
 3. **Execute**: Run the workflow to download and install the Insightface wheel
@@ -81,8 +81,9 @@ The node returns a status message indicating:
 ### Common Issues
 
 1. **"Python embedded not found"**
-   - Ensure you're using "Regular ComfyUI" if you don't have a portable installation
-   - Check that `python_embeded` folder exists in your ComfyUI root
+   - The installer should auto-detect your installation type, but you can manually override if needed
+   - If you have a portable installation, ensure the `python_embeded` folder exists in your ComfyUI root
+   - If auto-detection fails, manually select "Regular ComfyUI" for standard installations
 
 2. **"Download failed"**
    - Check your internet connection


### PR DESCRIPTION
## Problem
Users with portable ComfyUI installations had to manually select "Portable ComfyUI" even though the installer should be able to auto-detect the installation type. This created confusion and extra steps for users.

## Solution
This PR adds automatic detection logic that:

- **Auto-detects installation type** by checking for the existence of the `python_embeded` directory
- **Sets appropriate defaults** based on detection results
- **Provides clear logging** to show what was detected
- **Allows manual override** if auto-detection is incorrect

## Changes Made

### 🔧 Core Logic (`insightface_installer.py`)
- Added `_detect_installation_type()` static method that finds ComfyUI root and checks for portable installation indicators
- Modified `INPUT_TYPES()` to use auto-detected installation type as the default
- Enhanced logging to show detection results and manual overrides

### 📚 Documentation (`README.md`)
- Updated feature description to highlight auto-detection
- Modified usage instructions to reflect automatic detection
- Updated troubleshooting section with new auto-detection guidance

## How It Works

1. **Portable ComfyUI**: If `python_embeded` directory exists → defaults to "Portable ComfyUI"
2. **Regular ComfyUI**: If no `python_embeded` directory found → defaults to "Regular ComfyUI"
3. **Manual Override**: Users can still manually change the selection if needed

## Testing

The changes maintain backward compatibility while improving user experience:
- ✅ Existing workflows continue to work
- ✅ Manual selection still available
- ✅ Clear logging for debugging
- ✅ Robust error handling

## Benefits

- 🎯 **Better UX**: No more manual selection required for most users
- 🔍 **Transparent**: Clear logging shows what was detected
- 🛡️ **Robust**: Fallback to safe defaults if detection fails
- 🔧 **Flexible**: Manual override still available when needed

Fixes the issue where portable ComfyUI users had to manually select their installation type.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author